### PR TITLE
-L added to curl for redirect

### DIFF
--- a/wordpress/init.sls
+++ b/wordpress/init.sls
@@ -32,7 +32,7 @@ wordpress-database:
 
 get-wordpress:
   cmd.run:
-    - name: 'curl -O http://wordpress.org/latest.tar.gz && tar xvzf latest.tar.gz && /bin/rm latest.tar.gz'
+    - name: 'curl -O -L http://wordpress.org/latest.tar.gz && tar xvzf latest.tar.gz && /bin/rm latest.tar.gz'
     - cwd: /var/www/html/
     - unless: test -d /var/www/html/wordpress
     - require:


### PR DESCRIPTION
Curl -O  will only save the content in the html request producing a *.gz file with "301" error.
adding -L helps curl with the needed redirect.
