### PR TITLE
Default dbhost to localhost if it's not defined in the pillar

### DIFF
--- a/wordpress/config.sls
+++ b/wordpress/config.sls
@@ -1,10 +1,16 @@
 {% from "wordpress/map.jinja" import map with context %}
 {% for name, site in pillar['wordpress']['sites'].items() %}
 
+{% if 'dbhost' in site %}
+{% set dbhost = site.dbhost %}
+{% else %}
+{% set dbhost = 'localhost' %}
+{% endif %}
+
 # This command tells wp-cli to create our wp-config.php, DB info needs to be the same as above
 configure:
  cmd.run:
-  - name: '/usr/local/bin/wp core config --dbhost={{ site.dbhost }} --dbname={{ site.database }} --dbuser={{ site.dbuser }} --dbpass={{ site.dbpass }}'
+  - name: '/usr/local/bin/wp core config --dbhost={{ dbhost }} --dbname={{ site.database }} --dbuser={{ site.dbuser }} --dbpass={{ site.dbpass }}'
   - cwd: {{ map.docroot }}/{{ name }}
   - user: {{ map.www_user }}
 


### PR DESCRIPTION
There may be a more elegant way to do this in which case feel free to reject this pull request or make suggestions how it can be improved.

If not defaulting to localhost is intended behaviour then the "Pillar customizations" section of the README file should probably be modified to reflect this, since if dbhost is not defined the formula just flat out refuses to work.