### PR TITLE
document cli pillar and alter cmd.run states

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,31 +42,40 @@ Pillar customizations:
 .. code-block:: yaml
 
     wordpress:
-        sites:
-            sitename:
-              username: <your-wordpress-username>
-              password: <your-wordpress-user-password>
-              database: <your-wordpress-database-name>
-              dbuser: <your-wordpress-db-username>
-              dbpass: <your-wordpress-db-password>       
-              url: http://example.ie
-              title: 'My Blog'
-              email: 'john.doe@acme.com'       
-              plugins:
-                - '<plugin-name>'
+      cli:
+        source: https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+        hash: 2906a669a28d2a344da88c63c96aff3c
+      sites:
+        sitename:
+          username: <your-wordpress-username>
+          password: <your-wordpress-user-password>
+          database: <your-wordpress-database-name>
+          dbuser: <your-wordpress-db-username>
+          dbpass: <your-wordpress-db-password>
+          url: http://example.ie
+          title: 'My Blog'
+          email: 'john.doe@acme.com'
+          plugins:
+            - '<plugin-name>'
+
 Formula Dependencies
 ====================
 
-* `apache-formula <https://github.com/saltstack-formulas/apache-formula>`_
-* `php-formula <https://github.com/saltstack-formulas/php-formula>`_
+The `wordpress-formula` requires PHP, a MySQL client, and a webserver.
 
-or
+You may want to review the following formulas for help.
+
+* `php-formula <https://github.com/saltstack-formulas/php-formula>`_
+* `mysql-formula (mysql.client) <https://github.com/saltstack-formulas/mysql-formula#mysql-client>`_
+
+You also need either:
 
 * `nginx-formula <https://github.com/saltstack-formulas/nginx-formula>`_
-* `php-formula <https://github.com/saltstack-formulas/php-formula>`_
+* `apache-formula <https://github.com/saltstack-formulas/apache-formula>`_
 
 Author
 ======
 
 Nitin Madhok nmadhok@g.clemson.edu
+Russell Ballestrini russell@ballestrini.net
 Debian Fork by Starchy Grant starchy@gmail.com

--- a/wordpress/config.sls
+++ b/wordpress/config.sls
@@ -6,6 +6,7 @@ configure:
  cmd.run:
   - name: '/usr/local/bin/wp core config --dbhost={{ site.dbhost }} --dbname={{ site.database }} --dbuser={{ site.dbuser }} --dbpass={{ site.dbpass }}'
   - cwd: {{ map.docroot }}/{{ name }}
-  - user: {{ map.www_user }}
+  - runas: {{ map.www_user }}
+  - unless: test -f {{ map.docroot }}/{{ name }}/wp-config.php
 
 {% endfor %}

--- a/wordpress/init.sls
+++ b/wordpress/init.sls
@@ -16,7 +16,7 @@ download_wordpress_{{ id }}:
  cmd.run:
   - cwd: {{ map.docroot }}/{{ id }}
   - name: '/usr/local/bin/wp core download --path="{{ map.docroot }}/{{ id }}/"'
-  - user: {{ map.www_user }}
+  - runas: {{ map.www_user }}
   - unless: test -f {{ map.docroot }}/{{ id }}/wp-config.php
 
 # This command tells wp-cli to create our wp-config.php, DB info needs to be the same as above
@@ -24,7 +24,7 @@ configure_{{ id }}:
  cmd.run:
   - name: '/usr/local/bin/wp core config --dbname="{{ site.get('database') }}" --dbuser="{{ site.get('dbuser') }}" --dbpass="{{ site.get('dbpass') }}" --dbhost="{{ site.get('dbhost') }}" --path="{{ map.docroot }}/{{ id }}"'
   - cwd: {{ map.docroot }}/{{ id }}
-  - user: {{ map.www_user }}
+  - runas: {{ map.www_user }}
   - unless: test -f {{ map.docroot }}/{{ id }}/wp-config.php  
 
 # This command tells wp-cli to install wordpress
@@ -32,6 +32,6 @@ install_{{ id }}:
  cmd.run:
   - cwd: {{ map.docroot }}/{{ id }}
   - name: '/usr/local/bin/wp core install --url="{{ site.get('url') }}" --title="{{ site.get('title') }}" --admin_user="{{ site.get('username') }}" --admin_password="{{ site.get('password') }}" --admin_email="{{ site.get('email') }}" --path="{{ map.docroot }}/{{ id }}/"'
-  - user: {{ map.www_user }}
+  - runas: {{ map.www_user }}
   - unless: /usr/local/bin/wp core is-installed --path="{{ map.docroot }}/{{ id }}"
 {% endfor %}

--- a/wordpress/plugin.sls
+++ b/wordpress/plugin.sls
@@ -7,9 +7,9 @@ configure_plugin_{{ plugin_name }}:
  cmd.run:
   - name: '/usr/local/bin/wp plugin install --activate {{ plugin_name }}'
   - cwd: {{ map.docroot }}/{{ name }}
-  - user: {{ map.www_user }}
+  #- user: {{ map.www_user }}
+  - runas: {{ map.www_user }}
   - unless: '/usr/local/bin/wp plugin is-installed {{ plugin_name }}'
-  
 
     {% endfor %}
   {% endif %}


### PR DESCRIPTION
The readme didn't have an example pillar for CLI and therefore it caused confusion when the cli tool was an empty executable file.

This caused confusion for new users.

In addtion new versions of Salt Stack replaced cmd.run's `user` argument with `runas`.

As a result many states in this formula drifted and no longer work.

	modified:   README.rst
	modified:   wordpress/config.sls
	modified:   wordpress/init.sls
	modified:   wordpress/plugin.sls