### PR TITLE
Added support for plugins retrieved over a url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,10 @@ Pillar customizations:
           email: 'john.doe@acme.com'
           plugins:
             - '<plugin-name>'
+          plugins_url:
+            '<plugin-name>':
+              url: '<url-to-obtain-plugin-zipfile>'
+              name: '<plugin-name>'
 
 Formula Dependencies
 ====================

--- a/pillar.example
+++ b/pillar.example
@@ -26,5 +26,9 @@ wordpress:
             email: siteB@email.com
             plugins:
               - '<plugin-name>'
+            plugins_url:
+                '<plugin-name>':
+                    url: '<url-to-obtain-plugin-zipfile>'
+                    name: '<plugin-name>'
     lookup:
-        docroot: /var/html           
+        docroot: /var/html

--- a/wordpress/plugin.sls
+++ b/wordpress/plugin.sls
@@ -2,7 +2,7 @@
 {% from "wordpress/cli-allow-root.sls" import allowroot with context %}
 {% for name, site in pillar['wordpress']['sites'].items() %}
   {% if 'plugins' in pillar['wordpress']['sites'][name] %}
-    {% for plugin_name in pillar['wordpress']['sites'][name]['plugins'] %}  
+    {% for plugin_name in pillar['wordpress']['sites'][name]['plugins'] %}
 
 configure_plugin_{{ plugin_name }}:
  cmd.run:
@@ -11,6 +11,19 @@ configure_plugin_{{ plugin_name }}:
   #- user: {{ map.www_user }}
   - runas: {{ map.www_user }}
   - unless: '/usr/local/bin/wp plugin is-installed {{ allowroot }} {{ plugin_name }}'
+    {% endfor %}
+  {% endif %}
+
+  {% if 'plugins_url' in pillar['wordpress']['sites'][name] %}
+    {% for plugin_name, info in pillar['wordpress']['sites'][name]['plugins_url'].iteritems() %}
+
+configure_plugin_{{ info.name }}:
+ cmd.run:
+  - name: '/usr/local/bin/wp plugin install {{ allowroot }} --activate {{ info.url }}'
+  - cwd: {{ map.docroot }}/{{ name }}
+  #- user: {{ map.www_user }}
+  - runas: {{ map.www_user }}
+  - unless: '/usr/local/bin/wp plugin is-installed {{ allowroot }} {{ info.name }}'
     {% endfor %}
   {% endif %}
 {% endfor %}

--- a/wordpress/plugin.sls
+++ b/wordpress/plugin.sls
@@ -15,7 +15,7 @@ configure_plugin_{{ plugin_name }}:
   {% endif %}
 
   {% if 'plugins_url' in pillar['wordpress']['sites'][name] %}
-    {% for plugin_name, info in pillar['wordpress']['sites'][name]['plugins_url'].iteritems() %}
+    {% for plugin_name, info in pillar['wordpress']['sites'][name]['plugins_url'].items() %}
 
 configure_plugin_{{ info.name }}:
  cmd.run:


### PR DESCRIPTION
If we add a url to retrieve a plugin to pillars the test for installed-plugins would fail and on the test run it will report that this plugin will be installed. This PR provides separation for plugin URL's and names provided for them so tests wouldn't fail and whole state would be idempotent.